### PR TITLE
custom extend function

### DIFF
--- a/index.js
+++ b/index.js
@@ -328,13 +328,14 @@ cu.inherit = function inherit(receiver, provider, omit) {
  * });
  * ```
  * @param {Function} `Parent` Parent ctor
+ * @param {Function} `extend` Optional extend function to handle custom extensions. Useful when updating methods that require a specific prototype.
  *   @param {Function} `Child` Child ctor
  *   @param {Object} `proto` Optionally pass additional prototype properties to inherit.
  *   @return {Object}
  * @api public
  */
 
-cu.extend = function extend(Parent) {
+cu.extend = function extend(Parent, extend) {
   if (typeof Parent !== 'function') {
     throw new TypeError('expected Parent to be a function.');
   }
@@ -358,13 +359,10 @@ cu.extend = function extend(Parent) {
       }
     }
 
-    Ctor.prototype.mixin = function(key, value) {
-      Ctor.prototype[key] = value;
-    };
-
-    Ctor.extend = cu.extend(Ctor);
-    if (Parent.inherit) {
-      Ctor.inherit = Parent.inherit;
+    if (typeof extend === 'function') {
+      extend(Ctor, Parent);
     }
+
+    Ctor.extend = cu.extend(Ctor, extend);
   };
 };

--- a/test.js
+++ b/test.js
@@ -384,8 +384,6 @@ describe('extend', function() {
   it('should add descriptors to Ctor:', function() {
     var extend = cu.extend(Parent);
     extend(Ctor);
-    // add +1 for `mixin` method
-    assert.strictEqual(Ctor.prototype.count, 1);
   });
 
   it('should copy prototype properties to Ctor:', function() {
@@ -396,8 +394,12 @@ describe('extend', function() {
     assert(typeof Ctor.prototype.del === 'function');
   });
 
-  it('should add a mixin method to the prototype of Ctor:', function() {
-    var extend = cu.extend(Parent);
+  it('should add a mixin method to the prototype of Ctor using `extend` function:', function() {
+    var extend = cu.extend(Parent, function(Child) {
+      Child.prototype.mixin = function(key, val) {
+        Child.prototype[key] = val;
+      };
+    });
     extend(Ctor, App.prototype);
     assert(typeof Ctor.prototype.mixin === 'function');
     assert(typeof Ctor.prototype.get === 'function');
@@ -405,8 +407,12 @@ describe('extend', function() {
     assert(typeof Ctor.prototype.del === 'function');
   });
 
-  it('should mixin methods to the Ctor.prototype:', function() {
-    var extend = cu.extend(Parent);
+  it('should mixin methods to the Ctor.prototype using `extend` function:', function() {
+    var extend = cu.extend(Parent, function(Child) {
+      Child.prototype.mixin = function(key, val) {
+        Child.prototype[key] = val;
+      };
+    });
     extend(Ctor, App.prototype);
     var app = new Ctor();
     app.mixin('foo', function() {});


### PR DESCRIPTION
Allow passing custom extend function to `extend` to use for extending Child prototypes.
This removes the custom `mixin` code and lets us define that piece in `base-methods`. No we can make modifications in `base-methods` without having to update `class-utils`.

``` js
Base.extend = cu.extend(Base, function(Child, Parent) {
  Child.prototype.mixin = function(key, val) {
    Child.prototype[key] = val;
  };
});
```
