### PR TITLE
Bump dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "arr-union": "^3.1.0",
     "define-property": "^0.2.5",
-    "isobject": "^2.0.0",
+    "isobject": "^3.0.0",
     "lazy-cache": "^1.0.3",
     "static-extend": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "arr-union": "^3.1.0",
     "define-property": "^0.2.5",
     "isobject": "^3.0.0",
-    "lazy-cache": "^1.0.3",
+    "lazy-cache": "^2.0.2",
     "static-extend": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
For https://github.com/jonschlinkert/snapdragon/issues/6.
The `isobject` bump and the `lazy-cache` bump are in separate commits; I can split this into two PR's if you would like.