### PR TITLE
Remove false @return annotation for .inherit

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,6 @@ cu.copy = function copy(receiver, provider, omit) {
  * @param {Object} `receiver`
  * @param {Object} `provider`
  * @param {String|Array} `omit` One or more properties to omit
- * @return {Object}
  * @api public
  */
 


### PR DESCRIPTION
Annotation claims cu.inherit returns an object, but function has no return statements.